### PR TITLE
Adds default accuracy engine.

### DIFF
--- a/src/Voicebase.php
+++ b/src/Voicebase.php
@@ -18,7 +18,7 @@ class Voicebase
 	protected $parameters = [
 		'token', // required
 		'base_url', // optional
-		'accuracy_engine'
+		'accuracy_engine' // optional
 	];
 
 	/**
@@ -30,6 +30,15 @@ class Voicebase
 	 * @var string
 	 */
 	protected $token;
+
+	/**
+	 * Supported values are:
+	 * standard - the standard engine emphasizing speed over accuracy
+	 * premium - the premium engine emphasing high accuracy
+	 *
+	 * @var string
+	 */
+	protected $accuracy_engine = 'standard';
 
 	/**
 	 * @var string


### PR DESCRIPTION
After the latest commits were merged, the __construct() would spit an error about accuracy_engine not being set. I made it default to standard so that it's always set and doesn't cause errors.